### PR TITLE
default.nix: make it a function

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,6 @@
-# { stdenv, fetchFromGitHub, coq }:
+{
+  pkgs ? import <nixpkgs> { }
+}:
 
 # To use: run `nix-shell` or `nix-shell --run "exec zsh"`
 # https://nixos.org/wiki/Development_Environments
@@ -6,8 +8,7 @@
 
 let
   # Pin a nixpkgs version
-  _nixpkgs = import <nixpkgs> { };
-  pkgs = import (_nixpkgs.fetchFromGitHub {
+  pinned_pkgs = import (pkgs.fetchFromGitHub {
     owner  = "NixOS";
     repo   = "nixpkgs";
     # This is the commit that included math-classes. Thanks @vbgl!
@@ -15,10 +16,9 @@ let
     sha256 = "14s283bwh77266zslc96gr7zqaijq5b9k4wp272ry27j5q8l3h4i";
   }) {};
 
-  coq = pkgs.coq_8_5;
-  self = with pkgs; callPackage ./default.nix { };
+  coq = pinned_pkgs.coq_8_5;
 
-in with pkgs; stdenv.mkDerivation {
+in with pinned_pkgs; stdenv.mkDerivation {
   name = "coq${coq.coq-version}-typeclass-hierarchy";
   src = ./.;
   buildInputs = [ coq coqPackages_8_5.math-classes ];


### PR DESCRIPTION
This allows other packages to fetch and build this from Github. This _should_ work:
```nix
  coq_typeclass_hierarchy = callPackage (pinned_pkgs.fetchFromGitHub {
    owner  = "siddharthist";
    repo   = "coq-typeclass-hierarchy";
    # This is the commit that included monads.
    rev    = "8dd7689441417f90bf128c572bd0c247df38833b";
    sha256 = "1l58hql5rr4xgpnb06vnnqzkf3k4f3czba07p4snsybh86p8816c";
  }) { };
```
(I think). But it definitely doesn't now, because our `default.nix` builds a set, rather than a function (which `callPackage` requries).